### PR TITLE
POM changes I required to get Glimmer to build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-client</artifactId>
 			<version>${hadoop.version}</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.semanticweb.yars</groupId>
@@ -68,9 +67,14 @@
 			<version>1.2.strictNulls-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>it.unimi.di.big</groupId>
-			<artifactId>mg4j</artifactId>
-			<version>5.1</version>
+			<groupId>org.apache.ant</groupId>
+			<artifactId>ant</artifactId>
+			<version>1.9.2</version>
+		</dependency>
+		<dependency>
+			<groupId>it.unimi.di</groupId>
+			<artifactId>mg4j-big</artifactId>
+			<version>5.2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>jetty</artifactId>
@@ -113,7 +117,12 @@
 		</dependency>
 		<dependency>
 			<groupId>net.sourceforge.owlapi</groupId>
-			<artifactId>owlapi</artifactId>
+			<artifactId>owlapi-api</artifactId>
+			<version>3.3</version>
+		</dependency>
+		<dependency>
+			<groupId>net.sourceforge.owlapi</groupId>
+			<artifactId>owlapi-apibinding</artifactId>
 			<version>3.3</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
I was unable to get Glimmer to build out of the box, and found I had to make some changes to the POM to fix it. 

Some of the changes appear to be due to package naming (mg4j/mg4j-big, owlapi split into owlapi-api and owlapi-apibinding) and so are probably necessary, but others may just be due to my near total lack of familiarity with Maven; in particular, removing scope=provided on the Hadoop dependency. I'm not a Java developer any longer.

I had to guess about the version of mg4j-big, though it built correctly with 5.2.

I used Maven 3.0.4, FWIW.
