### PR TITLE
Fix nxparser

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,7 +12,7 @@ this project, but instead are separately downloaded from the respective provider
   http://hadoop.apache.org/
  
 * NxParser version 1.2.x (BSD - http://www.opensource.org/licenses/bsd-license.php)
-  http://code.google.com/p/nxparser/
+  https://github.com/nxparser/nxparser
   
 * MG4j version 5.1 (GNU Lesser General Public License - http://www.gnu.org/licenses/lgpl.html)
   http://mg4j.dsi.unimi.it/

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>org.semanticweb.yars</groupId>
 			<artifactId>nxparser</artifactId>
-			<version>1.2.strictNulls-SNAPSHOT</version>
+			<version>1.2.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.ant</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,17 +44,6 @@
 		</plugins>
 	</build>
 
-	<repositories>
-		<repository>
-			<id>aduna-software</id>
-			<url>http://repo.aduna-software.org/maven2/releases</url>
-		</repository>
-		<repository>
-			<id>nxparser-repo</id>
-			<url>http://nxparser.googlecode.com/svn/snapshots</url>
-		</repository>
-	</repositories>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
nxparser `1.2.strictNulls-SNAPSHOT` seems undownloadable in recent years or months, so I updated its version to `1.2.10`
I confirmed that `mvn test` passes all of the tests without any additional fixes.